### PR TITLE
Fix Acid Tango careers url

### DIFF
--- a/src/companies.ts
+++ b/src/companies.ts
@@ -33,7 +33,7 @@ export const companies: Companies = [
       },
     ],
     jobPage:
-      "https://www.linkedin.com/company/avantic-estudio-de-ingenieros/jobs",
+      "https://www.linkedin.com/company/acid-tango/jobs/",
   },
   {
     name: "Avantic",


### PR DESCRIPTION
Fix wrong url in Acid Tango description, was using the Avantic's LinkedIn jobs page.