### PR TITLE
Adds System73 Ltd. to the list of companies

### DIFF
--- a/src/companies.ts
+++ b/src/companies.ts
@@ -491,6 +491,31 @@ export const companies: Companies = [
     jobPage: "https://www.linkedin.com/company/squaads/jobs/",
   },
   {
+    name: "System73 Ltd.",
+    type: CompanyType.SOFTWARE_DEVELOPMENT,
+    website: "https://system73.com",
+    hiringFrom: [Island.TENERIFE],
+    socialNetworks: [
+      {
+        type: SocialNetworkType.FACEBOOK,
+        link: "https://www.facebook.com/system73limited",
+      },
+      {
+        type: SocialNetworkType.GITHUB,
+        link: "https://github.com/system73",
+      },
+      {
+        type: SocialNetworkType.LINKEDIN,
+        link: "https://www.linkedin.com/company/system-73",
+      },
+      {
+        type: SocialNetworkType.TWITTER,
+        link: "https://twitter.com/system73limited",
+      },
+    ],
+    jobPage: "https://system73.com/careers",
+  },
+  {
     name: "TecAlliance",
     type: CompanyType.SOFTWARE_DEVELOPMENT,
     website: "https://www.tecalliance.net",


### PR DESCRIPTION
Hello,

here, at System73, we want to contribute to the list of tech companies located in the Canary Islands.

Our company focuses on the delivery of media streaming over the Internet and offers related Software-as-a-Services.

System73 is open to remote work, but we still keep our physical office in Tenerife as part of the global company for those who want to work there.

We are currently hiring and encourage everyone to apply to join us.